### PR TITLE
Improve Windows build

### DIFF
--- a/JustDefineIt.cbp
+++ b/JustDefineIt.cbp
@@ -29,6 +29,7 @@
 					<Add option="-g" />
 					<Add option="-D_GLIBCXX_DEBUG" />
 					<Add option="-DDEBUG_MODE" />
+					<Add option="-Werror" />
 				</Compiler>
 			</Target>
 			<Target title="Debug-Render">
@@ -42,6 +43,7 @@
 					<Add option="-D_GLIBCXX_DEBUG" />
 					<Add option="-DDEBUG_MODE" />
 					<Add option="-DRENDER_ASTS" />
+					<Add option="-Werror" />
 				</Compiler>
 			</Target>
 			<Target title="Release">
@@ -108,7 +110,6 @@
 			<Add option="-pedantic" />
 			<Add option="-Wextra" />
 			<Add option="-Wall" />
-			<Add option="-Werror" />
 			<Add directory="./src" />
 		</Compiler>
 		<Unit filename="demo/main.cc">

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,53 @@
+jobs:
+- job: MINGW
+  pool:
+    vmImage: windows-latest
+  strategy:
+    matrix:
+      i686:
+        MINGW_UPPER: MINGW32
+        MINGW_LOWER: mingw32
+        MINGW_ARCH: i686
+      x86_64:
+        MINGW_UPPER: MINGW64
+        MINGW_LOWER: mingw64
+        MINGW_ARCH: x86_64
+  
+  steps:
+    - checkout: self
+
+    - powershell: |
+        choco install msys2
+      displayName: Install MSYS2
+    
+    - script: |
+        set PATH=C:\tools\msys64\usr\bin
+        C:\tools\msys64\usr\bin\pacman --noconfirm --needed -S git base-devel mingw-w64-$(MINGW_ARCH)-toolchain mingw-w64-$(MINGW_ARCH)-cmake mingw-w64-$(MINGW_ARCH)-gtest
+      displayName: Install Toolchain
+    
+    - script: |
+        set PATH=C:\tools\msys64\usr\bin
+        C:\tools\msys64\usr\bin\bash -lc "cmake -G \"Unix Makefiles\" CMakeLists.txt"
+      displayName: 'CMake Generate Makefiles'
+      env:
+        MSYSTEM: $(MINGW_UPPER)
+        CHERE_INVOKING: yes
+        MINGW_INSTALLS: $(MINGW_LOWER)
+        
+    - script: |
+        set PATH=C:\tools\msys64\usr\bin
+        C:\tools\msys64\usr\bin\bash -lc "make"
+      displayName: 'Build'
+      env:
+        MSYSTEM: $(MINGW_UPPER)
+        CHERE_INVOKING: yes
+        MINGW_INSTALLS: $(MINGW_LOWER)
+        
+    - script: |
+        set PATH=C:\tools\msys64\usr\bin
+        C:\tools\msys64\usr\bin\bash -lc "bin/Test/JustDefineIt"
+      displayName: 'Test'
+      env:
+        MSYSTEM: $(MINGW_UPPER)
+        CHERE_INVOKING: yes
+        MINGW_INSTALLS: $(MINGW_LOWER)

--- a/src/API/AST.h
+++ b/src/API/AST.h
@@ -25,19 +25,21 @@
  *
 **/
 
-#ifndef _AST__H
-#define _AST__H
-#define _AST__H__DEBUG // Used in debug_macros.h. Do not rename on a whim.
+#ifndef JDI_API_AST_h
+#define JDI_API_AST_h
+#define JDI_API_AST_h_debug // Used in debug_macros.h. Do not rename on a whim.
 
 #include "AST_forward.h"
 
-#include <string>
 #include <Storage/arg_key.h>
 #include <System/token.h>
 #include <System/lex_cpp.h>
 #include <Storage/value.h>
 #include <API/error_reporting.h>
 #include <Storage/definition.h>
+
+#include <string>
+#include <filesystem>
 
 namespace jdi {
 
@@ -558,7 +560,7 @@ class AST {
   void operate(jdi::ConstASTOperator *caop, void *p) const; ///< Perform some externally defined constant recursive operation on this AST.
 
   /// Render the AST to an SVG file.
-  void writeSVG(const char* filename);
+  void writeSVG(std::filesystem::path filename);
 
   /// Use this AST for template parameters
   inline void set_use_for_templates(bool use) { tt_greater_is_op = !use; }

--- a/src/API/AST_Export.cpp
+++ b/src/API/AST_Export.cpp
@@ -1,70 +1,89 @@
 /**
  * @file AST_Export.cpp
  * @brief Source implementing export functions for printing and rendering ASTs.
- * 
+ *
  * @section License
- * 
+ *
  * Copyright (C) 2011-2012 Josh Ventura
  * This file is part of JustDefineIt.
- * 
+ *
  * JustDefineIt is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
  * Foundation, version 3 of the License, or (at your option) any later version.
- * 
+ *
  * JustDefineIt is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with
  * JustDefineIt. If not, see <http://www.gnu.org/licenses/>.
 **/
 
 #include "AST.h"
 #include <General/svg_simple.h>
+
+#include <filesystem>
+
 using std::max;
 
 namespace jdi {
-  string AST::toString() const {
-    if (root) return root->toString();
-    return "";
-  }
+
+string AST::toString() const {
+  if (root) return root->toString();
+  return "";
 }
 
-namespace jdi
-{
-  /// A wrapper to \c SVG which generates IDs based on an internally-stored node count.
-  struct SVGrenderInfo {
-    SVG *svg;
-    AST_Node *cur;
-    int nodes_written;
-    
-    void draw_circle(int nid,int x,int y,int r,unsigned fill,unsigned stroke = 0xFF000000,int stroke_width = 2) { svg->draw_circle("Node"+svg->tostring(nid),x,y,r,fill,stroke,stroke_width); }
-    void draw_rectangle(int nid,int x1,int y1,int x2,int y2,unsigned fill,unsigned stroke = 0xFF000000,int stroke_width = 2) { svg->draw_rectangle("Node"+svg->tostring(nid),x1,y1,x2,y2,fill,stroke,stroke_width); }
-    void draw_line(int nid,char s_id,int x1,int y1,int x2,int y2,unsigned stroke = 0xFF000000,int stroke_width = 2) { svg->draw_line("Connector_"+svg->tostring(nid)+"_"+s_id,x1,y1,x2,y2,stroke,stroke_width); }
-    void draw_text(int nid,int cx,int bly,string t,unsigned fill = 0xFF000000) { svg->draw_text("Label_"+svg->tostring(nid),cx,bly,t,12,fill); }
-    
-    SVGrenderInfo(): svg(nullptr), cur(nullptr), nodes_written(0) {}
-    SVGrenderInfo(const char* fn): svg(new SVG(fn)), cur(nullptr), nodes_written(0) {}
-    ~SVGrenderInfo() { delete svg; }
-  };
-  
-  //===========================================================================================================================
-  //=: Node Widths :===========================================================================================================
-  //===========================================================================================================================
-  
-  int AST_Node::own_width() { return content.length()*8 + 16; }
-  int AST_Node_Type::own_width() { return dec_type.toString().length()*8 + 16; }
-  int AST_Node_Definition::own_width() { return def->name.length()*8 + 16; }
-  int AST_Node_Subscript::own_width() { return 24; }
-  int AST_Node::own_height() { return own_width(); }
-  int AST_Node_Cast::own_height() { return 24; }
-  int AST_Node_Type::own_height() { return 24; }
-  int AST_Node_Definition::own_height() { return 24; }
-  
-  //===========================================================================================================================
-  //=: SVG Renderers :=========================================================================================================
-  //===========================================================================================================================
-  
+/// A wrapper to \c SVG which helps generate IDs for each node.
+/// The caller is meant to increment the internal node count after all entities
+/// for that node have been written to the SVG.
+struct SVGrenderInfo {
+  SVG *svg;
+  AST_Node *cur;
+  size_t nodes_written = 0;
+
+  void draw_circle(int nid, int x, int y, int r, unsigned fill,
+                   unsigned stroke = 0xFF000000, int stroke_width = 2) {
+    svg->draw_circle("Node"+std::to_string(nid),
+                     x, y, r, fill, stroke, stroke_width);
+  }
+  void draw_rectangle(int nid, int x1, int y1, int x2, int y2, unsigned fill,
+                      unsigned stroke = 0xFF000000,int stroke_width = 2) {
+    svg->draw_rectangle("Node" + std::to_string(nid),
+                        x1, y1, x2, y2, fill, stroke, stroke_width);
+  }
+  void draw_line(int nid,char s_id, int x1, int y1, int x2, int y2,
+                 unsigned stroke = 0xFF000000, int stroke_width = 2) {
+    svg->draw_line("Connector_" + std::to_string(nid) + "_" + s_id,
+                   x1, y1, x2, y2, stroke, stroke_width);
+  }
+  void draw_text(int nid, int cx, int bly, string text,
+                 unsigned fill = 0xFF000000) {
+    svg->draw_text("Label_" + std::to_string(nid), cx, bly, text, 12, fill);
+  }
+
+  SVGrenderInfo(): svg(nullptr), cur(nullptr) {}
+  SVGrenderInfo(std::filesystem::path fn):
+      svg(new SVG(fn)), cur(nullptr) {}
+  ~SVGrenderInfo() { delete svg; }
+};
+
+//===========================================================================================================================
+//=: Node Widths :===========================================================================================================
+//===========================================================================================================================
+
+int AST_Node::own_width() { return content.length()*8 + 16; }
+int AST_Node_Type::own_width() { return dec_type.toString().length()*8 + 16; }
+int AST_Node_Definition::own_width() { return def->name.length()*8 + 16; }
+int AST_Node_Subscript::own_width() { return 24; }
+int AST_Node::own_height() { return own_width(); }
+int AST_Node_Cast::own_height() { return 24; }
+int AST_Node_Type::own_height() { return 24; }
+int AST_Node_Definition::own_height() { return 24; }
+
+//===========================================================================================================================
+//=: SVG Renderers :=========================================================================================================
+//===========================================================================================================================
+
   void AST_Node::toSVG(int x, int y, SVGrenderInfo *svg)
   {
     const int nid = svg->nodes_written++;
@@ -87,7 +106,7 @@ namespace jdi
   {
     const int nid = svg->nodes_written++;
     int xx = x, yy = y+own_height()/2+16+(operand?operand->own_height()/2:0);
-    
+
     svg->draw_line(nid,'m',x,y,xx,yy);
     svg->draw_circle(nid,x,y,own_width()/2,0xFFFFFFFF,svg->cur == this ? 0xFF00C000 : 0xFF000000,2);
     svg->draw_text(nid,x,y+4,content);
@@ -98,7 +117,7 @@ namespace jdi
   {
     const int nid = svg->nodes_written++;
     int xx = x, yy = y+own_height()/2+16+(operand?operand->own_height()/2:0);
-    
+
     int r = own_width()/2;
     svg->draw_line(nid,'m',x,y,xx,yy);
     svg->draw_rectangle(nid,x-r,y-12,x+r,y+12,0xFFFFFFFF,svg->cur == this ? 0xFF00C000 : 0xFF000000,2);
@@ -110,7 +129,7 @@ namespace jdi
   {
     const int nid = svg->nodes_written++;
     int xx = x, yy = y+own_height()/2+16+(operand?operand->own_width()/2:0);
-    
+
     int r = own_width()/2;
     svg->draw_line(nid,'m',x,y,xx,yy);
     svg->draw_rectangle(nid,x-r,y-12,x+r,y+12,0xFFFFFFFF,svg->cur == this ? 0xFF00C000 : 0xFF000000,2);
@@ -213,7 +232,7 @@ namespace jdi
   {
     const int nid = svg->nodes_written++;
     int xx = x, yy = y+own_height()/2+16+(bound?bound->own_width()/2:0);
-    
+
     content = (position?"new() ":"new ") + alloc_type.toString();
     if (bound) content += "[]";
     int r = own_width()/2;
@@ -226,7 +245,7 @@ namespace jdi
   void AST_Node_delete::toSVG(int x, int y, SVGrenderInfo *svg) {
     const int nid = svg->nodes_written++;
     int xx = x, yy = y+own_height()/2+16+(operand?operand->own_height()/2:0);
-    
+
     content = array?"delete[]":"delete";
     int r = own_width()/2;
     svg->draw_line(nid,'m',x,y,xx,yy);
@@ -251,22 +270,20 @@ namespace jdi
     if (index)
       index->toSVG(rx,y2r,svg);
   }
-}
 
-namespace jdi {
-  
+
   //===========================================================================================================================
   //=: Base Call :=============================================================================================================
   //===========================================================================================================================
-  
-  void AST::writeSVG(const char* filename) {
+
+  void AST::writeSVG(std::filesystem::path filename) {
     jdi::SVGrenderInfo svg(filename);
     svg.cur = nullptr;
     if (!svg.svg->is_open()) return;
-    
+
     int w, h;
-    
-    #ifdef DEBUG_MODE 
+
+    #ifdef DEBUG_MODE
       if (root)
         w = max(root->width(), (int)expression.length()*8)+8, h = root->height()+8 + 16;
       else
@@ -277,23 +294,21 @@ namespace jdi {
       else
         w = 8, h = 8;
     #endif
-    
+
     svg.svg->write_header(w,h);
     if (root)
       root->toSVG(w/2, root->own_height()/2+4, &svg);
-    #ifdef DEBUG_MODE 
+    #ifdef DEBUG_MODE
     svg.svg->draw_text("Expression",w/2,h-8,expression);
     #endif
     svg.svg->close();
   }
-}
 
-namespace jdi {
-  
+
   //===========================================================================================================================
   //=: Recursive Width/Height Resolvers :======================================================================================
   //===========================================================================================================================
-  
+
   int AST_Node            ::width()  { return own_width(); }
   int AST_Node_Binary     ::width()  { return 24 + (left?left->width():0) + (right?right->width():0); }
   int AST_Node_Unary      ::width()  { return operand?max(operand->width(),own_width()):own_width(); }
@@ -313,68 +328,81 @@ namespace jdi {
   int AST_Node_TempKeyInst::height() { return own_height(); }
   int AST_Node_Array      ::height() { int mh = 0; for (size_t i = 0; i < elements.size(); i++) mh = max(mh,elements[i]->height()); return own_width() + 16 + mh; }
   int AST_Node_Subscript  ::height() { return max((left?left->height():0), (index?index->height():0)) + 16 + own_height(); }
-  
-  
-  //===========================================================================================================================
-  //=: Basic Tree Print :======================================================================================================
-  //===========================================================================================================================
-  
-  string AST_Node::toString() const {
-    return content;
-  }
-  string AST_Node_Unary::toString() const {
-    return content + operand->toString();
-  }
-  string AST_Node_Binary::toString() const {
-    return "(" + (left? left->toString(): "...") + ") " + content + " (" + (right? right->toString() : "...") + ")";
-  }
-  string AST_Node_Ternary::toString() const {
-    return "(" + (exp?exp->toString():"...") + ")? (" + (left?left->toString():"...") + " : " + (right?right->toString():"...") + ")";
-  }
-  string AST_Node_Parameters::toString() const {
-    string res = "(" + (func?func->toString():"...") + ")(";
-    for (size_t i = 0; i < params.size(); ++i) { res += params[i]->toString(); if (i+1<params.size()) res += ", "; }
-    return res + ")";
-  }
-  string AST_Node_Cast::toString() const {
-    return "(" + cast_type.toString() + ")(" + operand->toString() + ")"; 
-  }
-  string AST_Node_Definition::toString() const {
-    return def? def->name : "...";
-  }
-  string AST_Node_Scope::toString() const {
-    return (left?left->toString() : "...") + "::" + (right?right->content:"???");
-  }
-  string AST_Node_sizeof::toString() const {
-    return "sizeof(" + operand->toString() + ")";
-  }
-  string AST_Node_Subscript::toString() const {
-    return "(" + (left? left->toString() : "...") + ")[" + (index? index->toString() : "...") + "]";
-  }
-  string AST_Node_Type::toString() const {
-    return dec_type.toString();
-  }
-  string AST_Node_Array::toString() const {
-    string res = "{ ";
-    for (size_t i = 0; i < elements.size(); ++i)
-      res += elements[i]->toString() + (i + 1 < elements.size()? ", " : " ");
-    return res + "}";
-  }
-  string AST_Node_new::toString() const {
-    string res = (position)? "new(" + position->toString() + ") " : "new ";
-    res += alloc_type.toString();
-    if (bound) res += "[" + bound->toString() + "]";
-    return res;
-  }
-  string AST_Node_delete::toString() const {
-    return (array?"delete ":"delete[] ") + operand->toString();
-  }
-  string AST_Node_TempInst::toString() const {
-    string res = temp? temp->toString() + "<" : "(<nullptr TEMPLATE>)<";
-    for (size_t i = 0; i < params.size(); ++i) { res += params[i]->toString(); if (i+1<params.size()) res += ", "; }
-    return res + ">";
-  }
-  string AST_Node_TempKeyInst::toString() const {
-    return (temp? temp->name + "<" : "(<nullptr TEMPLATE>)<") + key.toString() + ">";
-  }
+
+
+//===========================================================================================================================
+//=: Basic Tree Print :======================================================================================================
+//===========================================================================================================================
+
+string AST_Node::toString() const {
+  return content;
 }
+string AST_Node_Unary::toString() const {
+  return content + operand->toString();
+}
+string AST_Node_Binary::toString() const {
+  return "(" + (left? left->toString(): "...") + ") "
+         + content
+         + " (" + (right? right->toString() : "...") + ")";
+}
+string AST_Node_Ternary::toString() const {
+  return "(" + (exp ? exp->toString() : "...") + ") "
+         "? (" + (left?left->toString():"...") + ") "
+         ": (" + (right?right->toString():"...") + ")";
+}
+string AST_Node_Parameters::toString() const {
+  string res = "(" + (func?func->toString():"...") + ")(";
+  for (size_t i = 0; i < params.size(); ++i) {
+    res += params[i]->toString();
+    if (i + 1 < params.size()) res += ", ";
+  }
+  return res + ")";
+}
+string AST_Node_Cast::toString() const {
+  return "(" + cast_type.toString() + ")(" + operand->toString() + ")";
+}
+string AST_Node_Definition::toString() const {
+  return def? def->name : "...";
+}
+string AST_Node_Scope::toString() const {
+  return (left?left->toString() : "...") + "::" + (right?right->content:"???");
+}
+string AST_Node_sizeof::toString() const {
+  return "sizeof(" + operand->toString() + ")";
+}
+string AST_Node_Subscript::toString() const {
+  return "(" + (left? left->toString() : "...") + ")"
+         "[" + (index? index->toString() : "...") + "]";
+}
+string AST_Node_Type::toString() const {
+  return dec_type.toString();
+}
+string AST_Node_Array::toString() const {
+  string res = "{ ";
+  for (size_t i = 0; i < elements.size(); ++i)
+    res += elements[i]->toString() + (i + 1 < elements.size()? ", " : " ");
+  return res + "}";
+}
+string AST_Node_new::toString() const {
+  string res = (position)? "new(" + position->toString() + ") " : "new ";
+  res += alloc_type.toString();
+  if (bound) res += "[" + bound->toString() + "]";
+  return res;
+}
+string AST_Node_delete::toString() const {
+  return (array?"delete ":"delete[] ") + operand->toString();
+}
+string AST_Node_TempInst::toString() const {
+  string res = temp? temp->toString() + "<" : "(<nullptr TEMPLATE>)<";
+  for (size_t i = 0; i < params.size(); ++i) {
+    res += params[i]->toString();
+    if (i+1<params.size()) res += ", ";
+  }
+  return res + ">";
+}
+string AST_Node_TempKeyInst::toString() const {
+  return (temp ? temp->name + "<" : "(<nullptr TEMPLATE>)<")
+               + key.toString() + ">";
+}
+
+}  // namespace jdi

--- a/src/General/debug_macros.cpp
+++ b/src/General/debug_macros.cpp
@@ -1,22 +1,22 @@
 /**
  * @file  debug_macros.cpp
  * @brief Source implementing the conditional macros for parser debugging.
- * 
+ *
  * This file implements the ass-end of the debug macros.
  *
  * @section License
- * 
+ *
  * Copyright (C) 2011 Josh Ventura
  * This file is part of JustDefineIt.
- * 
+ *
  * JustDefineIt is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
  * Foundation, version 3 of the License, or (at your option) any later version.
- * 
+ *
  * JustDefineIt is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with
  * JustDefineIt. If not, see <http://www.gnu.org/licenses/>.
 **/
@@ -24,24 +24,25 @@
 #ifdef DEBUG_MODE
 #include <string>
 #include <cstdio>
+#include <filesystem>
 #include <API/AST.h>
 #include "debug_macros.h"
 
 using std::string;
 
 #include <sys/stat.h>
-static unsigned ast_rn = 0;
-void render_ast_nd(jdi::AST& ast, std::string cat)
-{
-  string fullp = DEBUG_OUTPUT_PATH "/AST_Renders/" + cat; // The full path to which this AST will be rendered.
-  
+void render_ast_nd(jdi::AST& ast, std::string cat) {
+  std::filesystem::path fullp = DEBUG_OUTPUT_PATH "/AST_Renders/";
+  fullp /= cat;  // The full path to which this AST will be rendered.
+
+  static unsigned ast_rn = 0;
   if (!ast_rn) {
-    mkdir(DEBUG_OUTPUT_PATH "/AST_Renders", 0777);
-    mkdir(fullp.c_str(),0777);
+    std::filesystem::create_directories(fullp);
   }
-  char fn[32]; sprintf(fn,"/ast_%08u.svg",ast_rn++);
-  fullp += fn;
-  
+  char fn[32];
+  sprintf(fn,"ast_%08u.svg", ast_rn++);
+  fullp /= fn;
+
   ast.writeSVG(fullp.c_str());
 }
 

--- a/src/General/debug_macros.h
+++ b/src/General/debug_macros.h
@@ -1,38 +1,38 @@
 /**
  * @file  debug_macros.h
  * @brief A header declaring conditional macros for your parser debugging convenience.
- * 
+ *
  * This file declares macros for reporting loop iterations, stack traces, and
  * other information that would otherwise need to be acquired via a debugger.
  *
  * @section License
- * 
+ *
  * Copyright (C) 2011 Josh Ventura
  * This file is part of JustDefineIt.
- * 
+ *
  * JustDefineIt is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
  * Foundation, version 3 of the License, or (at your option) any later version.
- * 
+ *
  * JustDefineIt is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with
  * JustDefineIt. If not, see <http://www.gnu.org/licenses/>.
 **/
+
+#ifndef JDI_GENERAL_DEBUG_MACROS_h
+#define JDI_GENERAL_DEBUG_MACROS_h
 
 /// Render an AST to an SVG, if debug AST rendering is enabled.
 /// @param AST The jdi::AST to render.
 /// @param cat The category under which the AST is rendered, such as "ArrayBounds".
 
-#ifndef _DEBUG_MACROS__H
-#define _DEBUG_MACROS__H
-
 #define render_ast(AST, cat) // Do nothing
 
 #ifdef DEBUG_MODE
-  
+
 #ifndef DEBUG_OUTPUT_PATH
 #define DEBUG_OUTPUT_PATH "/home/josh/Desktop"
 #endif
@@ -48,11 +48,10 @@ namespace jdi_debug {
 
 class RecursionHelper {
   size_t &count;
-  const size_t max;
  public:
   RecursionHelper(size_t &static_variable, size_t maximum_recursions):
-      count(static_variable), max(maximum_recursions) {
-    if (++count > max) asm("int3");
+      count(static_variable) {
+    if (++count > maximum_recursions) asm("int3");
   }
   ~RecursionHelper() { --count; }
 };
@@ -76,13 +75,11 @@ class RecursionHelper {
 #define SET_MAXIMUM_RECURSIONS(k)
 
 #endif  // DEBUG_MODE ELSE
-#endif  // Guard
 
-#ifndef _DEBUG_MACROS__H__RENDER_ASTS
-  #if defined(RENDER_ASTS) && defined(_AST__H__DEBUG)
-    #define _DEBUG_MACROS__H__RENDER_ASTS
-    #include <string>
-    #undef render_ast
-    void render_ast(jdi::AST& ast, std::string cat);
-  #endif
+#if defined(RENDER_ASTS) && defined(JDI_API_AST_h_debug)
+  #include <string>
+  #undef render_ast
+  void render_ast(jdi::AST& ast, std::string cat);
 #endif
+
+#endif  // Guard

--- a/src/General/llreader.cpp
+++ b/src/General/llreader.cpp
@@ -24,8 +24,12 @@
  * JustDefineIt. If not, see <http://www.gnu.org/licenses/>.
 **/
 
+#include "llreader.h"
+
 #include <cstdio>
 #include <cstring>
+#include <iostream>
+
 #if defined(_WIN32) || defined(__WIN32__) || defined(_WIN64) || defined(__WIN64__)
   #include <windows.h>
 #else
@@ -35,9 +39,6 @@
   #include <unistd.h>
   #include <fcntl.h>
 #endif
-
-#include "llreader.h"
-#include <iostream>
 
 /// Enumeration of open states for an \c llreader.
 enum {

--- a/src/General/svg_simple.cpp
+++ b/src/General/svg_simple.cpp
@@ -1,20 +1,20 @@
 /**
  * @file svg_simple.cpp
  * @brief Source implementing SVG functions.
- * 
+ *
  * @section License
- * 
+ *
  * Copyright (C) 2011 Josh Ventura
  * This file is part of JustDefineIt.
- * 
+ *
  * JustDefineIt is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
  * Foundation, version 3 of the License, or (at your option) any later version.
- * 
+ *
  * JustDefineIt is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with
  * JustDefineIt. If not, see <http://www.gnu.org/licenses/>.
 **/
@@ -22,8 +22,7 @@
 #include "svg_simple.h"
 
 using std::string;
-std::string SVG::escape(std::string e) {
-  string r = e;
+std::string SVG::escape(std::string r) {
   for (size_t i = 0; i < r.length(); i++)
     if (r[i] == '<')
       r.replace(i,1,"&lt;");
@@ -33,16 +32,21 @@ std::string SVG::escape(std::string e) {
       r.replace(i,1,"&amp;");
   return r;
 }
-std::string SVG::tostring(int id) { char buf[16]; sprintf(buf,"%d",id); return buf; }
 
 void SVG::write_header(int w, int h) {
   fputs("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>", f);
   fprintf(f,
-    "<svg xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:cc=\"http://creativecommons.org/ns#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" "
-    "xmlns:svg=\"http://www.w3.org/2000/svg\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:sodipodi=\"http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd\" width=\"%d\" "
-    "height=\"%d\" id=\"JDI_AST_Render\" version=\"1.1\" sodipodi:docname=\"JDI AST Render\">\n",w,h);
+    "<svg xmlns:dc=\"http://purl.org/dc/elements/1.1/\" "
+         "xmlns:cc=\"http://creativecommons.org/ns#\" "
+         "xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" "
+         "xmlns:svg=\"http://www.w3.org/2000/svg\" "
+         "xmlns=\"http://www.w3.org/2000/svg\" "
+         "xmlns:sodipodi=\"http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd\" "
+         "width=\"%d\" height=\"%d\" id=\"JDI_AST_Render\" "
+         "version=\"1.1\" sodipodi:docname=\"JDI AST Render\">\n",w,h);
   fputs("<g id=\"Drawing\">\n", f);
 }
+// TODO: SVG supports both <circle> and proper arc types, now.
 void SVG::draw_circle(std::string id, int x,int y,int r,unsigned fill,unsigned stroke, double stroke_width) {
   const int d = r * 2;
   fprintf(f, "  <path sodipodi:type=\"arc\" sodipodi:cx=\"%d\" sodipodi:cy=\"%d\" sodipodi:rx=\"%d\" sodipodi:ry=\"%d\" "
@@ -69,13 +73,13 @@ bool SVG::is_open() {
   return f;
 }
 void SVG::close() {
-  fputs("</g>\n",f);
-  fputs("</svg>\n",f);
+  fputs("</g>\n", f);
+  fputs("</svg>\n", f);
   fclose(f);
   f = nullptr;
 }
-SVG::SVG(const char* fn) {
-  f = fopen(fn, "wb");
+SVG::SVG(std::filesystem::path fn) {
+  f = fopen(fn.u8string().c_str(), "wb");
 }
 SVG::~SVG() {
   if (f) close();

--- a/src/General/svg_simple.h
+++ b/src/General/svg_simple.h
@@ -1,20 +1,20 @@
 /**
  * @file svg_simple.h
  * @brief A small library for creating simple SVG images.
- * 
+ *
  * @section License
- * 
+ *
  * Copyright (C) 2011 Josh Ventura
  * This file is part of JustDefineIt.
- * 
+ *
  * JustDefineIt is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
  * Foundation, version 3 of the License, or (at your option) any later version.
- * 
+ *
  * JustDefineIt is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with
  * JustDefineIt. If not, see <http://www.gnu.org/licenses/>.
 **/
@@ -22,6 +22,8 @@
 
 #include <cstdio>
 #include <string>
+#include <string>
+#include <filesystem>
 
 /**
   A class for exporting simple SVG images. The goal is to get along with Firefox, Chrome, and ImageMagick without bloating
@@ -29,62 +31,71 @@
 **/
 class SVG {
   FILE* f;
-  public:
-    /** Escape a string for writing to the file outside of a tag.
-        @param e  The string to be escaped.
-        @return   Returns an escaped copy of the string. **/
-    static std::string escape(std::string e);
-    /** Convenience function to rasterize an integer as a string.
-        @param d  The integer to be rasterized.
-        @return   Returns a string representing the given integer, in decimal. **/
-    static std::string tostring(int d);
-    /** Print the basic SVG information. This should always be the first call.
-        @param w  The width of the graphic, in pixels.
-        @param h  The height of the graphic, in pixels. **/
-    void write_header(int w, int h);
-    /** Render a circle to this SVG.
-        @param id            The unique id of this circle, as a string.
-        @param x             The x coordinate of the center of the circle.
-        @param y             The y coordinate of the center of the circle.
-        @param r             The radius of the circle.
-        @param fill          The fill color, in ARGB format. Defaults to full-alpha white.
-        @param stroke        The stroke color, in ARGB format. Defaults to full-alpha black.
-        @param stroke_width  The width of the stroke, in pixels. Defaults to 2. **/
-    void draw_circle(std::string id, int x,int y,int r,unsigned fill = 0xFFFFFFFF,unsigned stroke = 0xFF000000, double stroke_width = 2);
-    /** Render a line to this SVG.
-        @param id            The unique id of this line, as a string.
-        @param x1            The x coordinate of the first point on the line.
-        @param y1            The y coordinate of the first point on the line.
-        @param x2            The x coordinate of the second point on the line.
-        @param y2            The y coordinate of the second point on the line.
-        @param stroke        The stroke color, in ARGB format. Defaults to full-alpha black.
-        @param stroke_width  The width of the stroke, in pixels. Defaults to 2. **/
-    void draw_line(std::string id, int x1, int y1, int x2, int y2, unsigned stroke = 0xFF000000, float stroke_width = 2);
-    /** Render a rectangle to this SVG.
-        @param id            The unique id of this rectangle, as a string.
-        @param x1            The x coordinate of the top-left corner of the rectangle.
-        @param y1            The y coordinate of the top-left corner of the rectangle.
-        @param x2            The x coordinate of the bottom-right corner of the rectangle.
-        @param y2            The y coordinate of the bottom-right corner of the rectangle.
-        @param fill          The fill color, in ARGB format. Defaults to full-alpha white.
-        @param stroke        The stroke color, in ARGB format. Defaults to full-alpha white.
-        @param stroke_width  The width of the stroke, in pixels. Defaults to 2. **/
-    void draw_rectangle(std::string id, int x1, int y1, int x2, int y2, unsigned fill, unsigned stroke = 0xFF000000, float stroke_width = 2);
-    /** Render text to this SVG.
-        @param id            The unique id of the text, as a string.
-        @param cx            The x coordinate of the center of the text's baseline.
-        @param bly           The y coordinate of the text's baseline.
-        @param t             The text to be drawn.
-        @param sz            The size of the font.
-        @param color         The text color, in ARGB format. Defaults to full-alpha black. **/
-    void draw_text(std::string id, int cx, int bly, std::string t, int sz=12, unsigned color=0xFF000000);
-    /** Close the SVG file, writing closing body tags. **/
-    void close();
-    /** Check if the SVG file is currently open.
-        @return Returns true (1) if the file is open, false (0) otherwise. **/
-    bool is_open();
-    /** Default constructor. Opens the file, but does not write header data. **/
-    SVG(const char* fn);
-    /** Default destructor. Closes the file, writing closing tags, if it is still open. **/
-    ~SVG();
+ public:
+  /** Escape a string for writing to the file outside of a tag.
+      @param e  The string to be escaped.
+      @return   Returns an escaped copy of the string. **/
+  static std::string escape(std::string e);
+
+  /** Print the basic SVG information. This should always be the first call.
+      @param w  The width of the graphic, in pixels.
+      @param h  The height of the graphic, in pixels. **/
+  void write_header(int w, int h);
+
+  /** Render a circle to this SVG.
+      @param id            The unique id of this circle, as a string.
+      @param x             The x coordinate of the center of the circle.
+      @param y             The y coordinate of the center of the circle.
+      @param r             The radius of the circle.
+      @param fill          The fill color, in ARGB format. Defaults to full-alpha white.
+      @param stroke        The stroke color, in ARGB format. Defaults to full-alpha black.
+      @param stroke_width  The width of the stroke, in pixels. Defaults to 2. **/
+  void draw_circle(std::string id, int x,int y,int r,unsigned fill = 0xFFFFFFFF,
+                   unsigned stroke = 0xFF000000, double stroke_width = 2);
+
+  /** Render a line to this SVG.
+      @param id            The unique id of this line, as a string.
+      @param x1            The x coordinate of the first point on the line.
+      @param y1            The y coordinate of the first point on the line.
+      @param x2            The x coordinate of the second point on the line.
+      @param y2            The y coordinate of the second point on the line.
+      @param stroke        The stroke color, in ARGB format. Defaults to full-alpha black.
+      @param stroke_width  The width of the stroke, in pixels. Defaults to 2. **/
+  void draw_line(std::string id, int x1, int y1, int x2, int y2,
+                 unsigned stroke = 0xFF000000, float stroke_width = 2);
+
+  /** Render a rectangle to this SVG.
+      @param id            The unique id of this rectangle, as a string.
+      @param x1            The x coordinate of the top-left corner of the rectangle.
+      @param y1            The y coordinate of the top-left corner of the rectangle.
+      @param x2            The x coordinate of the bottom-right corner of the rectangle.
+      @param y2            The y coordinate of the bottom-right corner of the rectangle.
+      @param fill          The fill color, in ARGB format. Defaults to full-alpha white.
+      @param stroke        The stroke color, in ARGB format. Defaults to full-alpha white.
+      @param stroke_width  The width of the stroke, in pixels. Defaults to 2. **/
+  void draw_rectangle(std::string id, int x1, int y1, int x2, int y2,
+                      unsigned fill, unsigned stroke = 0xFF000000, float stroke_width = 2);
+
+  /** Render text to this SVG.
+      @param id            The unique id of the text, as a string.
+      @param cx            The x coordinate of the center of the text's baseline.
+      @param bly           The y coordinate of the text's baseline.
+      @param text          The text to be drawn.
+      @param sz            The size of the font.
+      @param color         The text color, in ARGB format. Defaults to full-alpha black. **/
+  void draw_text(std::string id, int cx, int bly, std::string text,
+                 int sz = 12, unsigned color = 0xFF000000);
+
+  /// Close the SVG file, writing closing body tags.
+  void close();
+
+  /// Check if the SVG file is currently open.
+  /// @return Returns true (1) if the file is open, false (0) otherwise.
+  bool is_open();
+
+  /// Default constructor. Opens the file, but does not write header data.
+  SVG(std::filesystem::path fn);
+
+  /// Default destructor. Closes the file, writing closing tags, if it is still open.
+  ~SVG();
 };

--- a/src/Parser/handlers/handle_declarators.cpp
+++ b/src/Parser/handlers/handle_declarators.cpp
@@ -49,7 +49,7 @@ int context_parser::handle_declarators(definition_scope *scope, token_t& token,
                                        definition* &res) {
   // Skip destructor tildes; log if we are a destructor
   bool dtor = token.type == TT_TILDE;
-  bool _inline = token.type == TT_DECFLAG && token.content.toString() == "inline";
+  const bool is_inline = token.type == TT_DECFLAG && token.content.view() == "inline";
   if (dtor) token = read_next_token(scope);
 
   // Outsource to read_fulltype, which will take care of the hard work for us.
@@ -90,7 +90,7 @@ int context_parser::handle_declarators(definition_scope *scope, token_t& token,
                                      herr->at(token));
       return !res;
     }
-    else if (_inline && token.type == TT_NAMESPACE) {
+    else if (is_inline && token.type == TT_NAMESPACE) {
       definition_scope *ns = handle_namespace(scope, token);
       if (!ns) return 1;
       scope->use_namespace(ns);

--- a/src/Storage/definition.cpp
+++ b/src/Storage/definition.cpp
@@ -652,7 +652,7 @@ string definition_template::toString(unsigned levels, unsigned indent) const {
     else {
       res += (d->integer_type.def? d->integer_type.toString() : "<ERROR>");
       if (d->flags & DEF_VALUED)
-        res += " = " + ((definition_valued*) d.get())->value_of;
+        res += " = " + ((definition_valued*) d.get())->value_of.toString();
     }
     first = false;
   }

--- a/src/System/lex_cpp.cpp
+++ b/src/System/lex_cpp.cpp
@@ -1118,8 +1118,9 @@ void lexer::handle_preprocessor() {
         #ifdef DEBUG_MODE
         {
           string n = read_preprocessor_args();
-          if (n == "DEBUG_ENTRY_POINT" and (conditionals.empty() or conditionals.back().is_true)) {
-            signal(SIGTRAP, donothing); // Try not to die when we raise hell in the interrupt handler briefly
+          if (n == "DEBUG_ENTRY_POINT" &&
+              (conditionals.empty() || conditionals.back().is_true)) {
+            signal(3, donothing); // Catch what we're about to raise in case there's no debugger
             asm("INT3;"); // Raise hell in the interrupt handler; the debugger will grab us from here
             cout << "* Debug entry point" << endl;
           }

--- a/test/MAIN.cc
+++ b/test/MAIN.cc
@@ -329,7 +329,7 @@ int main(int argc, char** argv) {
         printf("%2d : %2d  -  %d\n", a, b, ndiffs);
       ndiffs += diff;
     }
-    printf("Final stats: %lu correct, %lu incorrect\n", correct, incorrect);
+    printf("Final stats: %zu correct, %zu incorrect\n", correct, incorrect);
     return 0;
   }
 


### PR DESCRIPTION
Freshen some sources and apply some of ollydbg's patches.

- Use std::filesystem::path for SVG writing and directory creation.
- Remove an implicit string cast in a stream put.
- Rename `_inline` to `is_inline` and optimize content comparison.
- Move llreader include to top of file. It should be there anyway, stylistically, but including it after windows.h breaks shit.
- Move -Werror into non-demo targets.

Start revisiting some of the AST generation logic. It's not terrible, but it's using some dated representations of, eg, circles and ellipses. SVG supports ArcTo and proper circles, now. Actually, the current codegen seems to be SVG 1.1, so I guess I just wasn't aware of ellipses at the time.